### PR TITLE
Partial fix for OverlappingFileLockException when running tasks in pa…

### DIFF
--- a/src/sbt-test/sbt-idea-compiler-indices/simple-par/build.sbt
+++ b/src/sbt-test/sbt-idea-compiler-indices/simple-par/build.sbt
@@ -1,0 +1,36 @@
+import complete.DefaultParsers._
+import sbt.Def
+
+lazy val check = inputKey[Unit]("123")
+
+lazy val settings: Seq[Def.Setting[_]] = Seq(
+  check := {
+    val compilationInfoCount = (Space ~> NatBasic).parsed
+    val config               = configuration.value
+    val infoDirBase          = file("project") / "target" / ".sbt-compilation-infos" / s"root-$config"
+
+    val condition = infoDirBase.exists() && {
+      val infoFiles = infoDirBase.listFiles(_.getName.startsWith("compilation-info"))
+      infoFiles.size == compilationInfoCount
+    }
+
+    if (!condition) sys.error("Plugin check failed.")
+  }
+)
+
+lazy val root = project.in(file("."))
+  .settings(inConfig(Compile)(settings) ++ inConfig(Test)(settings))
+
+commands += Command.args("hammerTime", "Stop. Hammer Time!")({ (state: State, args: Seq[String]) => {
+  val runCount = args.head.toInt
+
+  val cCompState = Command.process("compile", state.copy(remainingCommands = List.empty))
+  val tCompState = Command.process("test:compile", cCompState.copy(remainingCommands = List.empty))
+  val remainingCommands = state.remainingCommands.take(1)
+  val parState = tCompState.copy(remainingCommands = remainingCommands)
+
+  (0 to runCount).par.foreach(_ => {
+    Command.process("testOnly", parState)
+  })
+  state
+}})

--- a/src/sbt-test/sbt-idea-compiler-indices/simple-par/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea-compiler-indices/simple-par/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("org.jetbrains" % "sbt-idea-compiler-indices" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-idea-compiler-indices/simple-par/src/main/scala/Test.scala
+++ b/src/sbt-test/sbt-idea-compiler-indices/simple-par/src/main/scala/Test.scala
@@ -1,0 +1,3 @@
+object hello {
+  println("Hello World!")
+}

--- a/src/sbt-test/sbt-idea-compiler-indices/simple-par/src/test/scala/helloTest.scala
+++ b/src/sbt-test/sbt-idea-compiler-indices/simple-par/src/test/scala/helloTest.scala
@@ -1,0 +1,3 @@
+object helloTest {
+  println("Hello world in Test")
+}

--- a/src/sbt-test/sbt-idea-compiler-indices/simple-par/test
+++ b/src/sbt-test/sbt-idea-compiler-indices/simple-par/test
@@ -1,0 +1,1 @@
+> hammerTime 10


### PR DESCRIPTION
This is not an issue if sbt-idea-compiler-indices plugin isn't loaded.

I'm basically trying to get around this when running multiple tasks in parallel in the intellij sbt shell:
```
[error] java.nio.channels.OverlappingFileLockException
[error] 	at java.base/sun.nio.ch.FileLockTable.checkList(FileLockTable.java:229)
[error] 	at java.base/sun.nio.ch.FileLockTable.add(FileLockTable.java:123)
[error] 	at java.base/sun.nio.ch.FileChannelImpl.lock(FileChannelImpl.java:1109)
[error] 	at java.base/java.nio.channels.FileChannel.lock(FileChannel.java:1063)
[error] 	at org.jetbrains.plugins.scala.indices.protocol.sbt.Locking$.lock(Locking.scala:23)
[error] 	at org.jetbrains.plugins.scala.indices.protocol.sbt.Locking$FileLockingExt$.lock$extension(Locking.scala:51)
[error] 	at org.jetbrains.sbt.indices.SbtIntellijIndicesPlugin$.$anonfun$perConfig$2(SbtIntellijIndicesPlugin.scala:62)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:834)
```